### PR TITLE
Use hex instead of disallowed octal escape codes

### DIFF
--- a/lib/grammar-ansi-coloring.coffee
+++ b/lib/grammar-ansi-coloring.coffee
@@ -106,17 +106,17 @@ ansiFormatted = (format) ->
 
   return [
     {
-      b: "(?<=\\033\\[|\\d;)(#{start};)"
+      b: "(?<=\\x1B\\[|\\d;)(#{start};)"
       c: { 1: "hidden.ansi-escape-code" }
       N: "terminal.ansi.#{name}#{extra}"
-      e: "(?=\\033\\[((?!#{end};)\\d+;)*#{end}(;\\d+)*m)"
+      e: "(?=\\x1B\\[((?!#{end};)\\d+;)*#{end}(;\\d+)*m)"
       p: [ "#ansiFormats" ]
     }
     {
-      b: "(?<=\\033\\[|\\d;)(#{start}m)"
+      b: "(?<=\\x1B\\[|\\d;)(#{start}m)"
       c: { 1: "hidden.ansi-escape-code" }
       N: "terminal.ansi.#{name}#{extra}"
-      e: "(?=\\033\\[((?!#{end};)\\d+;)*#{end}(;\\d+)*m)"
+      e: "(?=\\x1B\\[((?!#{end};)\\d+;)*#{end}(;\\d+)*m)"
       p: [ "#mainPatterns" ]
     }
   ]
@@ -127,13 +127,13 @@ grammar =
   patterns: [ "#ansiFormatted" ]
   repository:
     ansiFormatted:
-      b: /(\033\[)(?=(\d+;)*\d+m)/
+      b: /(\x1B\[)(?=(\d+;)*\d+m)/
       c: { 1: "hidden.ansi-escape-code" }
 
       n: "meta.ansi-formatted"
 
       L: true
-      e: /(?=\033\[\d+(;\d+)*m)/
+      e: /(?=\x1B\[\d+(;\d+)*m)/
 
       p: "#ansiFormats"
 


### PR DESCRIPTION
The ANSI grammar generator currently uses octal escape codes to match
escape characters, but they are disallowed in CoffeeScript strict mode
and in ES5 strict mode. Use hex escape codes instead, which yield the
same result and are supported.

Running `coffee lib/grammar-ansi-coloring.coffee` returns the following
error currently:

```
/atom-xikij/lib/grammar-ansi-coloring.coffee:130:12: error: octal escape
sequences are not allowed \03
    b: /(\033\[)(?=(\d+;)*\d+m)/
         ^^^
```
